### PR TITLE
feat(cli): add optional difficulty tag to problems

### DIFF
--- a/srl/commands/add.py
+++ b/srl/commands/add.py
@@ -66,8 +66,7 @@ def handle(args, console: Console):
         )
 
     save_json(PROGRESS_FILE, data)
-
-    # Remove from next up if it exists there
+    
     next_up = load_json(NEXT_UP_FILE)
     if name in next_up:
         del next_up[name]

--- a/srl/commands/add.py
+++ b/srl/commands/add.py
@@ -13,6 +13,12 @@ def add_subparser(subparsers):
     add = subparsers.add_parser("add", help="Add or update a problem attempt")
     add.add_argument("name", type=str, help="Name of the LeetCode problem")
     add.add_argument("rating", type=int, choices=range(1, 6), help="Rating from 1-5")
+    add.add_argument(
+        "difficulty",
+        nargs="?",
+        choices=["easy", "medium", "hard"],
+        help="Difficulty level (optional)",
+    )
     add.set_defaults(handler=handle)
     return add
 
@@ -20,6 +26,7 @@ def add_subparser(subparsers):
 def handle(args, console: Console):
     name: str = args.name
     rating: int = args.rating
+    difficulty: str = args.difficulty
 
     data = load_json(PROGRESS_FILE)
 
@@ -30,6 +37,8 @@ def handle(args, console: Console):
             "date": today().isoformat(),
         }
     )
+    if difficulty:
+        entry["difficulty"] = difficulty
 
     # Mastery check: last two ratings are 5
     history = entry["history"]
@@ -37,6 +46,11 @@ def handle(args, console: Console):
         mastered = load_json(MASTERED_FILE)
         if name in mastered:
             mastered[name]["history"].extend(history)
+            # Preserve existing difficulty if not provided in this update, or update if provided
+            if difficulty:
+                mastered[name]["difficulty"] = difficulty
+            elif "difficulty" in entry:
+                 mastered[name]["difficulty"] = entry["difficulty"]
         else:
             mastered[name] = entry
         save_json(MASTERED_FILE, mastered)

--- a/srl/commands/audit.py
+++ b/srl/commands/audit.py
@@ -94,7 +94,6 @@ def audit_fail(curr, console: Console):
         return
 
     entry = mastered[curr]
-    # Append new failed attempt
     entry["history"].append(
         {
             "rating": 1,
@@ -102,11 +101,9 @@ def audit_fail(curr, console: Console):
         }
     )
 
-    # Move to progress
     progress[curr] = entry
     save_json(PROGRESS_FILE, progress)
 
-    # Remove from mastered
     del mastered[curr]
     save_json(MASTERED_FILE, mastered)
 

--- a/srl/commands/inprogress.py
+++ b/srl/commands/inprogress.py
@@ -15,9 +15,21 @@ def add_subparser(subparsers):
 def handle(args, console: Console):
     in_progress = get_in_progress()
     if in_progress:
+        problem_lines = []
+        for name, difficulty in in_progress:
+            diff_tag = ""
+            if difficulty:
+                color = {
+                    "easy": "green",
+                    "medium": "yellow",
+                    "hard": "red",
+                }.get(difficulty.lower(), "white")
+                diff_tag = f" [{color}][{difficulty.capitalize()}][/{color}]"
+            problem_lines.append(f"• {name}{diff_tag}")
+
         console.print(
             Panel.fit(
-                "\n".join(f"• {p}" for p in in_progress),
+                "\n".join(problem_lines),
                 title=f"[bold magenta]Problems in Progress ({len(in_progress)})[/bold magenta]",
                 border_style="magenta",
                 title_align="left",
@@ -27,11 +39,12 @@ def handle(args, console: Console):
         console.print("[yellow]No problems currently in progress.[/yellow]")
 
 
-def get_in_progress() -> list[str]:
+def get_in_progress() -> list[tuple]:
     data = load_json(PROGRESS_FILE)
     res = []
 
-    for name, _ in data.items():
-        res.append(name)
+    for name, info in data.items():
+        difficulty = info.get("difficulty")
+        res.append((name, difficulty))
 
     return res

--- a/srl/commands/inprogress.py
+++ b/srl/commands/inprogress.py
@@ -4,6 +4,7 @@ from srl.storage import (
     load_json,
     PROGRESS_FILE,
 )
+from srl.utils import get_difficulty_tag
 
 
 def add_subparser(subparsers):
@@ -18,13 +19,7 @@ def handle(args, console: Console):
         problem_lines = []
         for name, difficulty in in_progress:
             diff_tag = ""
-            if difficulty:
-                color = {
-                    "easy": "green",
-                    "medium": "yellow",
-                    "hard": "red",
-                }.get(difficulty.lower(), "white")
-                diff_tag = f" [{color}][{difficulty.capitalize()}][/{color}]"
+            diff_tag = get_difficulty_tag(difficulty)
             problem_lines.append(f"• {name}{diff_tag}")
 
         console.print(

--- a/srl/commands/list_.py
+++ b/srl/commands/list_.py
@@ -32,9 +32,22 @@ def handle(args, console: Console):
 
     problems = get_due_problems(args.n)
     if problems:
+        problem_lines = []
+        for p in problems:
+            name, _, _, difficulty = p
+            diff_tag = ""
+            if difficulty:
+                color = {
+                    "easy": "green",
+                    "medium": "yellow",
+                    "hard": "red",
+                }.get(difficulty.lower(), "white")
+                diff_tag = f" [{color}][{difficulty.capitalize()}][/{color}]"
+            problem_lines.append(f"• {name}{diff_tag}")
+
         console.print(
             Panel.fit(
-                "\n".join(f"• {p}" for p in problems),
+                "\n".join(problem_lines),
                 title=f"[bold blue]Problems to Practice Today ({len(problems)})[/bold blue]",
                 border_style="blue",
                 title_align="left",
@@ -54,7 +67,7 @@ def should_audit():
     return random.random() < probability
 
 
-def get_due_problems(limit=None) -> list[str]:
+def get_due_problems(limit=None) -> list[tuple]:
     data = load_json(PROGRESS_FILE)
     due = []
 
@@ -66,15 +79,30 @@ def get_due_problems(limit=None) -> list[str]:
         last_date = datetime.fromisoformat(last["date"]).date()
         due_date = last_date + timedelta(days=last["rating"])
         if due_date <= today():
-            due.append((name, last_date, last["rating"]))
+            difficulty = info.get("difficulty")
+            due.append((name, last_date, last["rating"], difficulty))
 
     # Sort: older last attempt first, then lower rating
     due.sort(key=lambda x: (x[1], x[2]))
-    due_names = [name for name, _, _ in (due[:limit] if limit else due)]
+    
+    # Slice if limit is provided
+    if limit:
+        due = due[:limit]
 
-    if not due_names:
-        next_up = load_json(NEXT_UP_FILE)
-        fallback = list(next_up.keys())[: limit or 3]
-        return fallback
+    # If we have due problems, return them (as tuples)
+    if due:
+        return due
 
-    return due_names
+    # Fallback to Next Up if no due problems
+    next_up = load_json(NEXT_UP_FILE)
+    # We need to return tuples to match the format: (name, date, rating, difficulty)
+    # For Next Up items, date/rating are dummy values, difficulty is fetched if available
+    fallback_items = []
+    for name, info in list(next_up.items())[: limit or 3]:
+        # Next Up items in file don't store difficulty usually, but let's check if we save it there
+        # The current nextup implementation saves {"added": date}, but we might add difficulty there too.
+        # For now, let's assume difficulty might be there or None.
+        difficulty = info.get("difficulty")
+        fallback_items.append((name, None, None, difficulty))
+        
+    return fallback_items

--- a/srl/commands/list_.py
+++ b/srl/commands/list_.py
@@ -1,6 +1,6 @@
 from rich.console import Console
 from rich.panel import Panel
-from srl.utils import today
+from srl.utils import today, get_difficulty_tag
 from srl.commands.audit import get_current_audit, random_audit
 from datetime import datetime, timedelta
 import random
@@ -35,14 +35,7 @@ def handle(args, console: Console):
         problem_lines = []
         for p in problems:
             name, _, _, difficulty = p
-            diff_tag = ""
-            if difficulty:
-                color = {
-                    "easy": "green",
-                    "medium": "yellow",
-                    "hard": "red",
-                }.get(difficulty.lower(), "white")
-                diff_tag = f" [{color}][{difficulty.capitalize()}][/{color}]"
+            diff_tag = get_difficulty_tag(difficulty)
             problem_lines.append(f"• {name}{diff_tag}")
 
         console.print(

--- a/srl/commands/list_.py
+++ b/srl/commands/list_.py
@@ -78,11 +78,9 @@ def get_due_problems(limit=None) -> list[tuple]:
     # Sort: older last attempt first, then lower rating
     due.sort(key=lambda x: (x[1], x[2]))
     
-    # Slice if limit is provided
     if limit:
         due = due[:limit]
 
-    # If we have due problems, return them (as tuples)
     if due:
         return due
 

--- a/srl/commands/list_.py
+++ b/srl/commands/list_.py
@@ -92,9 +92,6 @@ def get_due_problems(limit=None) -> list[tuple]:
     # For Next Up items, date/rating are dummy values, difficulty is fetched if available
     fallback_items = []
     for name, info in list(next_up.items())[: limit or 3]:
-        # Next Up items in file don't store difficulty usually, but let's check if we save it there
-        # The current nextup implementation saves {"added": date}, but we might add difficulty there too.
-        # For now, let's assume difficulty might be there or None.
         difficulty = info.get("difficulty")
         fallback_items.append((name, None, None, difficulty))
         

--- a/srl/commands/mastered.py
+++ b/srl/commands/mastered.py
@@ -30,9 +30,18 @@ def handle(args, console: Console):
             table.add_column("Problem", style="cyan", no_wrap=True)
             table.add_column("Attempts", style="magenta")
             table.add_column("Mastered Date", style="green")
+            table.add_column("Difficulty", style="white")
 
-            for name, attempts, mastered_date in mastered_problems:
-                table.add_row(name, str(attempts), mastered_date)
+            for name, attempts, mastered_date, difficulty in mastered_problems:
+                diff_str = ""
+                if difficulty:
+                    color = {
+                        "easy": "green",
+                        "medium": "yellow",
+                        "hard": "red",
+                    }.get(difficulty.lower(), "white")
+                    diff_str = f"[{color}]{difficulty.capitalize()}[/{color}]"
+                table.add_row(name, str(attempts), mastered_date, diff_str)
 
             console.print(table)
 
@@ -47,6 +56,7 @@ def get_mastered_problems():
             continue
         attempts = len(history)
         mastered_date = history[-1]["date"]
-        mastered.append((name, attempts, mastered_date))
+        difficulty = info.get("difficulty")
+        mastered.append((name, attempts, mastered_date, difficulty))
 
     return mastered

--- a/srl/commands/nextup.py
+++ b/srl/commands/nextup.py
@@ -1,6 +1,6 @@
 from rich.console import Console
 from rich.panel import Panel
-from srl.utils import today
+from srl.utils import today, get_difficulty_tag
 from srl.storage import (
     load_json,
     save_json,
@@ -88,14 +88,7 @@ def handle(args, console: Console):
         if next_up:
             problem_lines = []
             for name, difficulty in next_up:
-                diff_tag = ""
-                if difficulty:
-                    color = {
-                        "easy": "green",
-                        "medium": "yellow",
-                        "hard": "red",
-                    }.get(difficulty.lower(), "white")
-                    diff_tag = f" [{color}][{difficulty.capitalize()}][/{color}]"
+                diff_tag = get_difficulty_tag(difficulty)
                 problem_lines.append(f"• {name}{diff_tag}")
 
             console.print(

--- a/srl/utils.py
+++ b/srl/utils.py
@@ -3,3 +3,14 @@ from datetime import datetime
 
 def today():
     return datetime.today().date()
+
+
+def get_difficulty_tag(difficulty: str) -> str:
+    if not difficulty:
+        return ""
+    color = {
+        "easy": "green",
+        "medium": "yellow",
+        "hard": "red",
+    }.get(difficulty.lower(), "white")
+    return f" [{color}][{difficulty.capitalize()}][/{color}]"


### PR DESCRIPTION
- Allow specifying difficulty (easy/medium/hard) as an optional positional argument in [add] command
- Support adding difficulty in `nextup` command
- Display color-coded difficulty tags in `list`, `inprogress`, and `nextup` outputs
- Add "Difficulty" column to `mastered` table
- Update help examples to show usage