### PR TITLE
Docs: update readme to include the python version needed to use the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Data is stored in the `~/.srl` directory, which is created automatically.
 
 ## Installation
 
+**Prerequisites**: Python 3.10+ is required.
+
 1. Clone the repo:
 
 ```bash


### PR DESCRIPTION
This pull request adds a prerequisite note to the installation instructions in the `README.md` file to clarify the required Python version.

* Documentation update:
  * Added a note specifying that Python 3.10+ is required in the installation section of `README.md`.