### PR TITLE
Feature/amend flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ You can also add an attempt by its number in the `srl list` output. This is usef
 srl add -n 1 3
 ```
 
+If you make a typo in the rating, use `--amend` to replace the last attempt instead of adding a new one. The original date is preserved.
+
+```bash
+srl add "Two Sum" 1        # Oops, meant 5
+srl add "Two Sum" 5 --amend  # Replaces the previous rating, keeps the date
+```
+
+`--amend` also works with `-n`:
+
+```bash
+srl add -n 1 5 --amend
+```
+
 ---
 
 ### Remove a Problem

--- a/srl/commands/add.py
+++ b/srl/commands/add.py
@@ -19,6 +19,7 @@ def add_subparser(subparsers):
     )
     add.add_argument("rating", type=int, choices=range(1, 6), help="Rating from 1-5")
     add.add_argument("-u", "--url", type=str, help="URL to the problem")
+    add.add_argument("--amend", action="store_true", help="Replace the latest rating instead of adding a new attempt")
     add.set_defaults(handler=handle)
     return add
 
@@ -47,7 +48,17 @@ def handle(args, console: Console):
     # Use existing name if found, otherwise use the provided name
     target_name = existing_name if existing_name else name
     entry = data.get(target_name, {"history": []})
-    entry["history"].append(
+    if getattr(args, "amend", False):
+        if target_name not in data:
+            console.print(f"[bold red]Problem '{target_name}' not found in progress[/bold red]")
+            return
+        elif entry["history"]:
+            entry["history"][-1]["rating"] = rating
+        else:
+            console.print(f"[bold red]No attempts found for '{target_name}'[/bold red]")
+            return
+    else:
+        entry["history"].append(
         {
             "rating": rating,
             "date": today().isoformat(),

--- a/tests/test_commands/test_add.py
+++ b/tests/test_commands/test_add.py
@@ -321,3 +321,66 @@ def test_move_problem_with_url_to_mastered(mock_data, console, load_json):
     mastered = load_json(mock_data.MASTERED_FILE)
     assert problem in mastered
     assert mastered[problem]["url"] == url
+
+def test_amend_replaces_last_rating(mock_data, console, load_json):
+    problem = "Replaces last entry"
+
+    args = SimpleNamespace(name=problem, rating=1, number=None, amend=False)
+    add.handle(args=args, console=console)
+
+    args = SimpleNamespace(name=problem, rating=5, number=None, amend=True)
+    add.handle(args=args, console=console)
+
+    progress = load_json(mock_data.PROGRESS_FILE)
+    assert len(progress[problem]["history"]) == 1
+    assert progress[problem]["history"][-1]["rating"] == 5
+
+def test_amend_preserves_original_date(mock_data, console, load_json, dump_json):
+    problem = "Preserves date"
+    original_date = "2025-11-14"
+
+    # Pre-populate with a known date
+    dump_json(mock_data.PROGRESS_FILE, {
+        problem: {"history": [{"rating": 1, "date": original_date}]}
+    })
+
+    args = SimpleNamespace(name=problem, rating=5, number=None, amend=True)
+    add.handle(args=args, console=console)
+
+    progress = load_json(mock_data.PROGRESS_FILE)
+    assert progress[problem]["history"][-1]["date"] == original_date
+
+def test_amend_on_nonexistent_problem_shows_error(mock_data, console, load_json):
+    problem = "Nonexistent problem"
+    args = SimpleNamespace(name=problem, rating=5, number=None, amend=True)
+    add.handle(args=args, console=console)
+
+    assert "not found in progress" in console.export_text()
+
+def test_amend_on_problem_with_no_history_shows_error(mock_data, console, load_json, dump_json):
+    problem = "No history"
+
+    # Problem exists in progress but has no attempts
+    dump_json(mock_data.PROGRESS_FILE, {problem: {"history": []}})
+
+    args = SimpleNamespace(name=problem, rating=5, number=None, amend=True)
+    add.handle(args=args, console=console)
+
+    assert "No attempts found" in console.export_text()
+
+def test_amend_with_number_flag(mock_data, console, load_json, backdate_problem):
+    problem = "Amend with number"
+
+    args = SimpleNamespace(name=problem, rating=4, number=None, amend=False)
+    add.handle(args=args, console=console)
+
+    # Make it due so -n 1 can find it
+    backdate_problem(problem, 5)
+
+    args = SimpleNamespace(name=None, rating=5, number=1, amend=True)
+    add.handle(args=args, console=console)
+
+    progress = load_json(mock_data.PROGRESS_FILE)
+    assert len(progress[problem]["history"]) == 1
+    assert progress[problem]["history"][-1]["rating"] == 5
+


### PR DESCRIPTION
Fixes  #74 

Summary
Adds an `--amend` flag to `srl add` that replaces the latest rating instead of appending a new attempt.

Changes
- `srl/commands/add.py`: added `--amend` to the subparser and branched the handle logic to replace `history[-1]["rating"]` instead of appending, with error handling for nonexistent problems and empty history
- `tests/test_commands_add.py`: added 5 tests, covering: replaces last rating, preserves date, error on nonexistent problem, error on empty history, and works with `-n` flag
- `README.md`: documented `--amend` usage under the "Add or Update a Problem Attempt" section
- All tests introduced in the PR passed successfully