### PR TITLE
Feature/ledger filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ srl ledger
 
 Displays a table of all your attempts across in-progress, mastered, and audit categories, sorted by date.
 
+You can filter to a specific problem by name or by number from `srl list`:
+
+```bash
+srl ledger "Two Sum"
+srl ledger -n 1
+```
+
+This renders a focused view showing all attempts for that problem, sorted most recent first, with the title `Two Sum (3)` indicating the total attempt count.
+
 You can show the count of attempts by passing in the `-c` or `--count` flag.
 
 ```bash

--- a/srl/commands/ledger.py
+++ b/srl/commands/ledger.py
@@ -7,12 +7,19 @@ from srl.storage import (
     MASTERED_FILE,
     AUDIT_FILE,
 )
-
+from srl.commands.list_ import get_due_problems
 
 def add_subparser(subparsers):
     parser = subparsers.add_parser("ledger", help="Print a summary of all attempts")
     parser.add_argument(
         "-c", "--count", action="store_true", help="Show only the count of problems"
+    )
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument(
+        "name", nargs="?", type=str, help="Name of the problem to filter by"
+    )
+    group.add_argument(
+        "-n", "--number", type=int, help="Problem number from `srl list`"
     )
     parser.set_defaults(handler=handle)
     return parser
@@ -25,12 +32,27 @@ def handle(args, console: Console):
 
     all_attempts = []
 
+    name = getattr(args, "name", None)
+    number = getattr(args, "number", None)
+
+    # Resolve --number to an exact problem name (matches srl list output)
+    if number is not None:
+        due = get_due_problems()
+        if number < 1 or number > len(due):
+            console.print(f"[red]Invalid problem number:[/red] {number}")
+            return
+        name = due[number - 1]
+
     # Process progress and mastered problems
     for data, status in (
         (progress_data, "progress"),
         (mastered_data, "mastered"),
     ):
         for problem_url, problem_data in data.items():
+            if number is not None and problem_url != name:
+                continue
+            if name and number is None and name.lower() not in problem_url.lower():
+                continue
             for attempt in problem_data.get("history", []):
                 all_attempts.append(
                     {
@@ -46,6 +68,8 @@ def handle(args, console: Console):
         result = attempt["result"]
         if result == "fail":
             continue
+        if name and name.lower() not in attempt["problem"].lower():
+            continue
         all_attempts.append(
             {
                 "date": attempt["date"],
@@ -57,9 +81,35 @@ def handle(args, console: Console):
 
     all_attempts.sort(key=lambda x: x["date"])
 
+    if name and not all_attempts:
+        console.print(f"[red]No problem found matching '{name}'.[/red]")
+        return
+
     count_only = getattr(args, "count", False)
     if count_only:
         console.print(f"Total attempts: {len(all_attempts)}")
+    elif name and all_attempts:
+        focused_table = Table(
+            title=f"{name} ({len(all_attempts)})",
+            box=box.ROUNDED,
+        )
+        focused_table.add_column("Date", style="white")
+        focused_table.add_column("Rating", justify="center")
+        focused_table.add_column("Status", justify="center")
+
+        for attempt in reversed(all_attempts):
+            rating_color = "green" if attempt["rating"] >= 4 else "red"
+            rating_text = f"[{rating_color}]★ {attempt['rating']}[/{rating_color}]"
+            status_color = {
+                "progress": "yellow",
+                "mastered": "green",
+                "audit": "blue",
+            }.get(attempt["status"], "white")
+            status_text = f"[{status_color}]{attempt['status']}[/{status_color}]"
+
+            focused_table.add_row(attempt["date"], rating_text, status_text)
+
+        console.print(focused_table)
     elif all_attempts:
         timeline_table = Table(box=box.ROUNDED)
         timeline_table.add_column("Date", style="white")

--- a/tests/test_commands/test_ledger.py
+++ b/tests/test_commands/test_ledger.py
@@ -195,3 +195,113 @@ def test_ledger_audit_failure_double_counting(console, mock_data, dump_json):
     assert (
         problem_occurrences == 3
     ), f"Expected 3 total occurrences of {problem} (2 initial + 1 after fail), got {problem_occurrences}"
+
+
+def test_ledger_filter_by_name_shows_focused_view(console, mock_data, dump_json):
+    progress_data = {
+        "two-sum": {"history": [{"rating": 3, "date": "2025-01-15"}]},
+        "valid-parentheses": {"history": [{"rating": 4, "date": "2025-01-14"}]},
+    }
+    dump_json(mock_data.PROGRESS_FILE, progress_data)
+
+    args = SimpleNamespace(name="two-sum")
+    ledger.handle(args=args, console=console)
+
+    output = console.export_text()
+    assert "two-sum" in output
+    assert "two-sum (1)" in output
+    assert "valid-parentheses" not in output
+
+
+def test_ledger_filter_by_name_finds_mastered_problem(console, mock_data, dump_json):
+    mastered_data = {
+        "merge-intervals": {"history": [{"rating": 5, "date": "2025-01-10"}]}
+    }
+    dump_json(mock_data.MASTERED_FILE, mastered_data)
+
+    args = SimpleNamespace(name="merge-intervals")
+    ledger.handle(args=args, console=console)
+
+    output = console.export_text()
+    assert "merge-intervals" in output
+    assert "merge-intervals (1)" in output
+
+
+def test_ledger_filter_by_name_not_found(console):
+    args = SimpleNamespace(name="nonexistent-problem")
+    ledger.handle(args=args, console=console)
+
+    output = console.export_text()
+    assert "No problem found matching" in output
+
+
+def test_ledger_filter_by_name_sorted_most_recent_first(console, mock_data, dump_json):
+    progress_data = {
+        "two-sum": {
+            "history": [
+                {"rating": 3, "date": "2025-01-10"},
+                {"rating": 4, "date": "2025-01-15"},
+                {"rating": 5, "date": "2025-01-20"},
+            ]
+        }
+    }
+    dump_json(mock_data.PROGRESS_FILE, progress_data)
+
+    args = SimpleNamespace(name="two-sum")
+    ledger.handle(args=args, console=console)
+
+    output = console.export_text()
+    lines = output.strip().split("\n")
+    date_lines = [line for line in lines if "2025-01-" in line]
+    assert "2025-01-20" in date_lines[0]
+    assert "2025-01-15" in date_lines[1]
+    assert "2025-01-10" in date_lines[2]
+
+
+def test_ledger_filter_by_name_includes_audit_attempts(console, mock_data, dump_json):
+    progress_data = {
+        "two-sum": {"history": [{"rating": 3, "date": "2025-01-10"}]}
+    }
+    dump_json(mock_data.PROGRESS_FILE, progress_data)
+
+    audit_data = {
+        "history": [
+            {"date": "2025-01-15", "problem": "two-sum", "result": "pass"},
+            {"date": "2025-01-16", "problem": "other-problem", "result": "pass"},
+        ]
+    }
+    dump_json(mock_data.AUDIT_FILE, audit_data)
+
+    args = SimpleNamespace(name="two-sum")
+    ledger.handle(args=args, console=console)
+
+    output = console.export_text()
+    assert "two-sum (2)" in output
+    assert "other-problem" not in output
+
+
+def test_ledger_filter_by_number(console, mock_data, dump_json):
+    progress_data = {
+        "two-sum": {"history": [{"rating": 1, "date": "2025-01-01"}]},
+    }
+    dump_json(mock_data.PROGRESS_FILE, progress_data)
+
+    args = SimpleNamespace(number=1)
+    ledger.handle(args=args, console=console)
+
+    output = console.export_text()
+    assert "two-sum" in output
+    assert "two-sum (1)" in output
+
+
+def test_ledger_filter_by_number_out_of_range(console, mock_data, dump_json):
+    progress_data = {
+        "two-sum": {"history": [{"rating": 1, "date": "2025-01-01"}]},
+    }
+    dump_json(mock_data.PROGRESS_FILE, progress_data)
+
+    args = SimpleNamespace(number=99)
+    ledger.handle(args=args, console=console)
+
+    output = console.export_text()
+    assert "Invalid problem number" in output


### PR DESCRIPTION
Fixes #77 

## Summary
Added optional `name` and `-n/--number` arguments to filter the ledger by a specific problem.

## Changes
`srl/commands/ledger.py`:
-  Added a mutually exclusive argument group for problem `name` and `-n/--number`
  - Added a new focused table view with the title `Problem Name ({number of attempts})` showing date, rating (with ★), and status
  - The fiilter retrieves data from both `problems_in_progress.json` and `problems_mastered.json`, and includes audit attempts
  - Prints an error if the `name` filter matches nothing, or if `-n ` is out of range
  - When no filter is given, existing full-ledger behavior is preserved

`tests/test_commands/test_ledger.py`: 
- Added 7 tests, covering: searches mastered problems, searches problems from `srl list` (by both name and number), error on invalid number, error on invalid name, orders attempts from newest to oldest, renders table with the correct title, omits unnecessary data
- All tests introduced in the PR passed

`README.md`:
- Documented `srl ledger name` and `srl ledger -n` usage