### PR TITLE
feat: add pause/resume functionality for 'due' problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ If no problems are due today, it will fall back to showing problems from the Nex
 
 ---
 
+### Pause the Schedule
+
+If you want to take time off without letting overdue problems pile up, pause the schedule:
+
+```bash
+srl pause
+```
+
+This freezes your due schedule at the day you paused. Problems will not keep stacking up while you are away.
+
+When you come back, resume it explicitly:
+
+```bash
+srl resume
+```
+
+`srl unpause` is also available as an alias.
+
+Active work commands such as `srl add` automatically resume the schedule first, so the gap is treated as time off and your spacing is preserved without having to tell SRL how many days you were away.
+
+---
+
 ### View In-Progress Problems
 
 ```bash

--- a/srl/cli.py
+++ b/srl/cli.py
@@ -4,6 +4,8 @@ from srl.commands import (
     list_,
     mastered,
     inprogress,
+    pause,
+    resume,
     calendar,
     nextup,
     audit,
@@ -24,6 +26,8 @@ def build_parser() -> argparse.ArgumentParser:
     list_.add_subparser(subparsers)
     mastered.add_subparser(subparsers)
     inprogress.add_subparser(subparsers)
+    pause.add_subparser(subparsers)
+    resume.add_subparser(subparsers)
     calendar.add_subparser(subparsers)
     nextup.add_subparser(subparsers)
     audit.add_subparser(subparsers)

--- a/srl/commands/add.py
+++ b/srl/commands/add.py
@@ -1,5 +1,6 @@
 from rich.console import Console
 from srl.utils import today
+from srl.pause_state import resume_schedule
 from srl.storage import (
     load_json,
     save_json,
@@ -27,6 +28,8 @@ def add_subparser(subparsers):
 def handle(args, console: Console):
     rating: int = args.rating
     url: str = getattr(args, "url", "")
+    name = None
+
     if hasattr(args, "number") and args.number is not None:
         problems = get_due_problems()
         if args.number > len(problems) or args.number <= 0:
@@ -34,7 +37,9 @@ def handle(args, console: Console):
             return
         name = problems[args.number - 1]
     else:
-        name: str = args.name
+        name = args.name
+
+    resume_schedule(console=console, auto=True)
 
     data = load_json(PROGRESS_FILE)
 

--- a/srl/commands/audit.py
+++ b/srl/commands/audit.py
@@ -1,5 +1,6 @@
 from rich.console import Console
 from srl.utils import today
+from srl.pause_state import resume_schedule
 from datetime import datetime
 import random
 from srl.storage import (
@@ -47,6 +48,7 @@ def handle_default(args, console: Console):
 def handle_pass(args, console: Console):
     curr = get_current_audit()
     if curr:
+        resume_schedule(console=console, auto=True)
         audit_pass(curr)
         console.print("[green]Audit passed![/green]")
     else:
@@ -56,6 +58,7 @@ def handle_pass(args, console: Console):
 def handle_fail(args, console: Console):
     curr = get_current_audit()
     if curr:
+        resume_schedule(console=console, auto=True)
         audit_fail(curr, console)
         console.print("[red]Audit failed.[/red] Problem moved back to in-progress.")
     else:

--- a/srl/commands/list_.py
+++ b/srl/commands/list_.py
@@ -1,6 +1,7 @@
 from rich.console import Console
 from rich.panel import Panel
 from srl.utils import today
+from srl.pause_state import effective_today, get_paused_on, is_paused
 from srl.commands.audit import get_current_audit, random_audit, get_last_audit_date
 from datetime import datetime, timedelta
 import random
@@ -21,7 +22,13 @@ def add_subparser(subparsers):
 
 
 def handle(args, console: Console):
-    if should_audit() and not get_current_audit():
+    schedule_day = effective_today()
+
+    if is_paused():
+        console.print(
+            f"[yellow]Schedule paused since {get_paused_on().isoformat()}.[/yellow]"
+        )
+    elif should_audit() and not get_current_audit():
         problem = random_audit()
         if problem:
             console.print("[bold red]You have been randomly audited![/bold red]")
@@ -44,7 +51,7 @@ def handle(args, console: Console):
         console.print(
             Panel.fit(
                 "\n".join(lines),
-                title=f"[bold blue]Problems to Practice [{today().isoformat()}] ({len(problems)})[/bold blue]",
+                title=f"[bold blue]Problems to Practice [{schedule_day.isoformat()}] ({len(problems)})[/bold blue]",
                 border_style="blue",
                 title_align="left",
             )
@@ -54,13 +61,17 @@ def handle(args, console: Console):
 
 
 def should_audit():
+    if is_paused():
+        return False
+
     cfg = Config.load()
+    schedule_day = effective_today()
 
     # Check max days without audit first
     if cfg.max_days_without_audit and cfg.max_days_without_audit > 0:
         last_audit_date = get_last_audit_date()
         if last_audit_date:
-            days_since_last = (today() - last_audit_date).days
+            days_since_last = (schedule_day - last_audit_date).days
             if days_since_last >= cfg.max_days_without_audit:
                 return True
 
@@ -76,6 +87,7 @@ def should_audit():
 def get_due_problems(limit=None, include_url=False) -> list[str]:
     data = load_json(PROGRESS_FILE)
     due = []
+    schedule_day = effective_today()
 
     for name, info in data.items():
         url = info.get("url", "")
@@ -85,7 +97,7 @@ def get_due_problems(limit=None, include_url=False) -> list[str]:
         last = history[-1]
         last_date = datetime.fromisoformat(last["date"]).date()
         due_date = last_date + timedelta(days=last["rating"])
-        if due_date <= today():
+        if due_date <= schedule_day:
             due.append((name, last_date, last["rating"], url))
 
     # Sort: older last attempt first, then lower rating

--- a/srl/commands/pause.py
+++ b/srl/commands/pause.py
@@ -1,0 +1,26 @@
+from rich.console import Console
+
+from srl.pause_state import get_paused_on, pause_schedule
+
+
+def add_subparser(subparsers):
+    parser = subparsers.add_parser(
+        "pause",
+        help="Pause your review schedule until you resume",
+    )
+    parser.set_defaults(handler=handle)
+    return parser
+
+
+def handle(args, console: Console):
+    paused_on = pause_schedule()
+    if paused_on is None:
+        existing = get_paused_on()
+        console.print(
+            f"[yellow]Schedule is already paused since {existing.isoformat()}.[/yellow]"
+        )
+        return
+
+    console.print(
+        f"[green]Paused[/green] your schedule on {paused_on.isoformat()}. Run [cyan]srl resume[/cyan] when you return."
+    )

--- a/srl/commands/resume.py
+++ b/srl/commands/resume.py
@@ -1,0 +1,18 @@
+from rich.console import Console
+
+from srl.pause_state import resume_schedule
+
+
+def add_subparser(subparsers):
+    parser = subparsers.add_parser(
+        "resume",
+        aliases=["unpause"],
+        help="Resume your review schedule after a pause",
+    )
+    parser.set_defaults(handler=handle)
+    return parser
+
+
+def handle(args, console: Console):
+    if not resume_schedule(console=console, auto=False):
+        console.print("[yellow]Schedule is not paused.[/yellow]")

--- a/srl/pause_state.py
+++ b/srl/pause_state.py
@@ -1,0 +1,92 @@
+from datetime import date, datetime, timedelta
+
+from rich.console import Console
+
+from srl.storage import PAUSE_FILE, PROGRESS_FILE, load_json, save_json
+from srl.utils import today
+
+
+def get_paused_on() -> date | None:
+    paused_on = load_json(PAUSE_FILE).get("paused_on")
+    if not paused_on:
+        return None
+    return date.fromisoformat(paused_on)
+
+
+def is_paused() -> bool:
+    return get_paused_on() is not None
+
+
+def effective_today() -> date:
+    return get_paused_on() or today()
+
+
+def pause_schedule() -> date | None:
+    paused_on = get_paused_on()
+    if paused_on:
+        return None
+
+    paused_on = today()
+    save_json(PAUSE_FILE, {"paused_on": paused_on.isoformat()})
+    return paused_on
+
+
+def clear_pause():
+    save_json(PAUSE_FILE, {})
+
+
+def paused_days() -> int:
+    paused_on = get_paused_on()
+    if not paused_on:
+        return 0
+    return max((today() - paused_on).days, 0)
+
+
+def resume_schedule(console: Console | None = None, auto: bool = False) -> bool:
+    paused_on = get_paused_on()
+    if not paused_on:
+        return False
+
+    days = paused_days()
+    shift_in_progress(days)
+    clear_pause()
+
+    if console is not None:
+        prefix = "Automatically resumed" if auto else "Resumed"
+        if days == 0:
+            console.print(f"[green]{prefix}[/green] your schedule.")
+        else:
+            day_label = "day" if days == 1 else "days"
+            console.print(
+                f"[green]{prefix}[/green] your schedule after {days} paused {day_label}."
+            )
+
+    return True
+
+
+def shift_in_progress(days: int) -> int:
+    if days <= 0:
+        return 0
+
+    data = load_json(PROGRESS_FILE)
+    shifted = 0
+
+    for info in data.values():
+        history = info.get("history", [])
+        if not history:
+            continue
+
+        history[-1]["date"] = shift_iso_date(history[-1]["date"], days)
+        shifted += 1
+
+    if shifted:
+        save_json(PROGRESS_FILE, data)
+
+    return shifted
+
+
+def shift_iso_date(value: str, days: int) -> str:
+    if "T" in value:
+        return (datetime.fromisoformat(value) + timedelta(days=days)).isoformat()
+
+    return (date.fromisoformat(value) + timedelta(days=days)).isoformat()

--- a/srl/storage.py
+++ b/srl/storage.py
@@ -7,6 +7,7 @@ MASTERED_FILE = DATA_DIR / "problems_mastered.json"
 NEXT_UP_FILE = DATA_DIR / "next_up.json"
 AUDIT_FILE = DATA_DIR / "audit.json"
 CONFIG_FILE = DATA_DIR / "config.json"
+PAUSE_FILE = DATA_DIR / "pause.json"
 
 
 def ensure_data_dir():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import srl.commands
+import srl.pause_state
 from srl.utils import today
 from rich.console import Console
 from dataclasses import dataclass
@@ -16,6 +17,7 @@ class Paths:
     NEXT_UP_FILE: pathlib.Path
     AUDIT_FILE: pathlib.Path
     CONFIG_FILE: pathlib.Path
+    PAUSE_FILE: pathlib.Path
 
 
 @pytest.fixture
@@ -52,6 +54,7 @@ def mock_data(tmp_path, monkeypatch):
         NEXT_UP_FILE=tmp_path / "next_up.json",
         AUDIT_FILE=tmp_path / "audit.json",
         CONFIG_FILE=tmp_path / "config.json",
+        PAUSE_FILE=tmp_path / "pause.json",
     )
 
     for name, path in vars(paths).items():
@@ -59,6 +62,8 @@ def mock_data(tmp_path, monkeypatch):
         for mod in vars(srl.commands).values():
             if hasattr(mod, name):
                 monkeypatch.setattr(f"{mod.__name__}.{name}", path)
+        if hasattr(srl.pause_state, name):
+            monkeypatch.setattr(f"srl.pause_state.{name}", path)
         monkeypatch.setattr(f"srl.storage.{name}", path)
 
     yield paths

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,24 @@ def test_list_with_n(parser):
     assert args.n == 5
 
 
+def test_pause_command_default_days(parser):
+    args = parser.parse_args(["pause"])
+    assert args.command == "pause"
+    assert hasattr(args, "handler")
+
+
+def test_resume_command(parser):
+    args = parser.parse_args(["resume"])
+    assert args.command == "resume"
+    assert hasattr(args, "handler")
+
+
+def test_unpause_alias_command(parser):
+    args = parser.parse_args(["unpause"])
+    assert args.command == "unpause"
+    assert hasattr(args, "handler")
+
+
 def test_mastered_count_short_flag(parser):
     args = parser.parse_args(["mastered", "-c"])
     assert args.command == "mastered"

--- a/tests/test_commands/test_pause.py
+++ b/tests/test_commands/test_pause.py
@@ -1,0 +1,152 @@
+from datetime import timedelta
+from types import SimpleNamespace
+
+from srl.commands import add, list_, nextup, pause
+from srl.commands import resume
+from srl.utils import today
+
+
+def test_pause_sets_paused_state(console, load_json, mock_data):
+    pause.handle(SimpleNamespace(), console)
+
+    pause_data = load_json(mock_data.PAUSE_FILE)
+    assert pause_data["paused_on"] == today().isoformat()
+
+    output = console.export_text()
+    assert "Paused" in output
+    assert "srl resume" in output
+
+
+def test_pause_twice_reports_existing_state(console):
+    pause.handle(SimpleNamespace(), console)
+    pause.handle(SimpleNamespace(), console)
+
+    output = console.export_text()
+    assert "already paused" in output
+
+
+def test_list_uses_frozen_schedule_while_paused(
+    console, load_json, dump_json, mock_data, monkeypatch
+):
+    monkeypatch.setattr(list_, "should_audit", lambda: False)
+
+    add.handle(SimpleNamespace(name="Soon Due", rating=3), console)
+    add.handle(SimpleNamespace(name="Later Problem", rating=5), console)
+    console.clear()
+
+    data = load_json(mock_data.PROGRESS_FILE)
+    data["Soon Due"]["history"][-1]["date"] = (today() - timedelta(days=5)).isoformat()
+    data["Later Problem"]["history"][-1]["date"] = (
+        today() - timedelta(days=2)
+    ).isoformat()
+    dump_json(mock_data.PROGRESS_FILE, data)
+
+    dump_json(mock_data.PAUSE_FILE, {"paused_on": (today() - timedelta(days=2)).isoformat()})
+
+    list_.handle(SimpleNamespace(n=None, url=False), console)
+
+    output = console.export_text()
+    assert "Schedule paused since" in output
+    assert "Soon Due" in output
+    assert "Later Problem" not in output
+
+
+def test_resume_shifts_schedule_by_elapsed_days(
+    console, load_json, dump_json, mock_data, monkeypatch
+):
+    monkeypatch.setattr(list_, "should_audit", lambda: False)
+
+    add.handle(SimpleNamespace(name="Soon Due", rating=3), console)
+    add.handle(SimpleNamespace(name="Later Problem", rating=5), console)
+    console.clear()
+
+    data = load_json(mock_data.PROGRESS_FILE)
+    data["Soon Due"]["history"][-1]["date"] = (today() - timedelta(days=4)).isoformat()
+    data["Later Problem"]["history"][-1]["date"] = (
+        today() - timedelta(days=2)
+    ).isoformat()
+    dump_json(mock_data.PROGRESS_FILE, data)
+    dump_json(mock_data.PAUSE_FILE, {"paused_on": (today() - timedelta(days=2)).isoformat()})
+
+    resume.handle(SimpleNamespace(), console)
+
+    updated = load_json(mock_data.PROGRESS_FILE)
+    assert updated["Soon Due"]["history"][-1]["date"] == (
+        today() - timedelta(days=2)
+    ).isoformat()
+    assert updated["Later Problem"]["history"][-1]["date"] == today().isoformat()
+    assert load_json(mock_data.PAUSE_FILE) == {}
+
+    output = console.export_text()
+    assert "Resumed" in output
+    assert "2 paused days" in output
+
+    console.clear()
+    list_.handle(SimpleNamespace(n=None, url=False), console)
+
+    output = console.export_text()
+    assert "No problems due today or in Next Up" in output
+
+
+def test_pause_defaults_to_one_day(console, load_json, dump_json, mock_data):
+    pause.handle(SimpleNamespace(), console)
+    assert load_json(mock_data.PAUSE_FILE)["paused_on"] == today().isoformat()
+
+
+def test_pause_skips_nextup_and_mastered(console, load_json, mock_data):
+    add.handle(SimpleNamespace(name="Mastered Problem", rating=5), console)
+    add.handle(SimpleNamespace(name="Mastered Problem", rating=5), console)
+    nextup.handle(SimpleNamespace(action="add", name="Queued Problem"), console)
+    console.clear()
+
+    pause.handle(SimpleNamespace(), console)
+
+    mastered = load_json(mock_data.MASTERED_FILE)
+    next_up = load_json(mock_data.NEXT_UP_FILE)
+
+    assert "Mastered Problem" in mastered
+    assert next_up["Queued Problem"]["added"] == today().isoformat()
+
+
+def test_resume_without_pause(console):
+    resume.handle(SimpleNamespace(), console)
+
+    output = console.export_text()
+    assert "Schedule is not paused" in output
+
+
+def test_add_auto_resumes_schedule(console, load_json, dump_json, mock_data):
+    add.handle(SimpleNamespace(name="Problem A", rating=3), console)
+    console.clear()
+
+    data = load_json(mock_data.PROGRESS_FILE)
+    data["Problem A"]["history"][-1]["date"] = (today() - timedelta(days=4)).isoformat()
+    dump_json(mock_data.PROGRESS_FILE, data)
+    dump_json(mock_data.PAUSE_FILE, {"paused_on": (today() - timedelta(days=2)).isoformat()})
+
+    add.handle(SimpleNamespace(name="Problem A", rating=4), console)
+
+    progress = load_json(mock_data.PROGRESS_FILE)
+    history = progress["Problem A"]["history"]
+
+    assert history[0]["date"] == (today() - timedelta(days=2)).isoformat()
+    assert history[1]["date"] == today().isoformat()
+    assert history[1]["rating"] == 4
+    assert load_json(mock_data.PAUSE_FILE) == {}
+
+    output = console.export_text()
+    assert "Automatically resumed" in output
+
+
+def test_audit_pass_auto_resumes_schedule(console, load_json, dump_json, mock_data):
+    from srl.commands import audit
+
+    dump_json(mock_data.AUDIT_FILE, {"current_audit": "Audit Problem"})
+    dump_json(mock_data.PAUSE_FILE, {"paused_on": (today() - timedelta(days=3)).isoformat()})
+
+    audit.handle_pass(SimpleNamespace(), console)
+
+    assert load_json(mock_data.PAUSE_FILE) == {}
+    output = console.export_text()
+    assert "Automatically resumed" in output
+    assert "Audit passed!" in output


### PR DESCRIPTION
- Freezes due scheduling while paused so overdue problems do not accumulate during time away
- Adds a real schedule pause flow with srl pause, srl resume, and srl unpause
- Automatically resumes the schedule on active work commands like srl add and audit completion
- Updates CLI parsing, storage, docs, and tests to cover the new pause/resume behavior