### PR TITLE
Clean up ledger command

### DIFF
--- a/srl/commands/ledger.py
+++ b/srl/commands/ledger.py
@@ -25,6 +25,11 @@ def add_subparser(subparsers):
     return parser
 
 
+def format_rating(rating):
+    color = "green" if rating >= 4 else "red"
+    return f"[{color}]{rating}[/{color}]"
+
+
 def handle(args, console: Console):
     progress_data = load_json(PROGRESS_FILE)
     mastered_data = load_json(MASTERED_FILE)
@@ -95,19 +100,11 @@ def handle(args, console: Console):
         )
         focused_table.add_column("Date", style="white")
         focused_table.add_column("Rating", justify="center")
-        focused_table.add_column("Status", justify="center")
 
-        for attempt in reversed(all_attempts):
-            rating_color = "green" if attempt["rating"] >= 4 else "red"
-            rating_text = f"[{rating_color}]★ {attempt['rating']}[/{rating_color}]"
-            status_color = {
-                "progress": "yellow",
-                "mastered": "green",
-                "audit": "blue",
-            }.get(attempt["status"], "white")
-            status_text = f"[{status_color}]{attempt['status']}[/{status_color}]"
+        for attempt in all_attempts:
+            rating_text = format_rating(attempt["rating"])
 
-            focused_table.add_row(attempt["date"], rating_text, status_text)
+            focused_table.add_row(attempt["date"], rating_text)
 
         console.print(focused_table)
     elif all_attempts:
@@ -115,20 +112,12 @@ def handle(args, console: Console):
         timeline_table.add_column("Date", style="white")
         timeline_table.add_column("Problem", style="cyan")
         timeline_table.add_column("Rating", justify="center")
-        timeline_table.add_column("Status", justify="center")
 
         for attempt in all_attempts:
-            rating_color = "green" if attempt["rating"] >= 4 else "red"
-            rating_text = f"[{rating_color}]{attempt['rating']}[/{rating_color}]"
-            status_color = {
-                "progress": "yellow",
-                "mastered": "green",
-                "audit": "blue",
-            }.get(attempt["status"], "white")
-            status_text = f"[{status_color}]{attempt['status']}[/{status_color}]"
+            rating_text = format_rating(attempt["rating"])
 
             timeline_table.add_row(
-                attempt["date"], attempt["problem"], rating_text, status_text
+                attempt["date"], attempt["problem"], rating_text
             )
 
         console.print(timeline_table)

--- a/tests/test_commands/test_ledger.py
+++ b/tests/test_commands/test_ledger.py
@@ -110,7 +110,6 @@ def test_ledger_after_adding_progress_attempt(console):
     output = console.export_text()
     assert "two-sum" in output
     assert " 4 " in output
-    assert "progress" in output
 
 
 def test_ledger_count_flag_displays_count_only(console, mock_data, dump_json):
@@ -235,7 +234,7 @@ def test_ledger_filter_by_name_not_found(console):
     assert "No problem found matching" in output
 
 
-def test_ledger_filter_by_name_sorted_most_recent_first(console, mock_data, dump_json):
+def test_ledger_filter_by_name_sorted_oldest_first(console, mock_data, dump_json):
     progress_data = {
         "two-sum": {
             "history": [
@@ -253,9 +252,9 @@ def test_ledger_filter_by_name_sorted_most_recent_first(console, mock_data, dump
     output = console.export_text()
     lines = output.strip().split("\n")
     date_lines = [line for line in lines if "2025-01-" in line]
-    assert "2025-01-20" in date_lines[0]
+    assert "2025-01-10" in date_lines[0]
     assert "2025-01-15" in date_lines[1]
-    assert "2025-01-10" in date_lines[2]
+    assert "2025-01-20" in date_lines[2]
 
 
 def test_ledger_filter_by_name_includes_audit_attempts(console, mock_data, dump_json):


### PR DESCRIPTION
## Summary
- Remove ★ character from ratings
- Fix ordering: both views now show oldest first (was reverse for focused)
- Remove Status column from both focused and timeline tables
- Extract `format_rating()` helper to eliminate duplicate code