### PR TITLE
Add summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,23 @@ srl config --reset-colors
 
 ---
 
+### Summary Command
+
+The `summary` command displays a consolidated view of all your SRL statistics:
+
+```bash
+srl summary
+```
+
+This prints:
+- Total attempts across all problems
+- Total mastered problems count
+- Total in-progress problems count
+- Audit statistics (total, passed, failed, pass rate)
+- Calendar heatmap from your first recorded entry
+
+---
+
 ### Server Command
 
 Run an HTTP server that exposes the srl CLI via a simple JSON API.

--- a/srl/cli.py
+++ b/srl/cli.py
@@ -13,6 +13,7 @@ from srl.commands import (
     server,
     random,
     ledger,
+    summary,
 )
 
 
@@ -33,4 +34,5 @@ def build_parser() -> argparse.ArgumentParser:
     server.add_subparser(subparsers)
     random.add_subparser(subparsers)
     ledger.add_subparser(subparsers)
+    summary.add_subparser(subparsers)
     return parser

--- a/srl/commands/calendar.py
+++ b/srl/commands/calendar.py
@@ -42,7 +42,7 @@ def handle(args, console: Console):
         months = getattr(args, "months", 12)
 
     render_activity(console, counts, colors, months)
-    console.print("-" * 5)
+    console.print(f"[dim]{'─' * 5}[/dim]")
     render_legend(console, colors)
 
 

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -1,0 +1,92 @@
+from rich.console import Console
+from srl.storage import (
+    load_json,
+    PROGRESS_FILE,
+    MASTERED_FILE,
+    AUDIT_FILE,
+)
+from srl.commands.calendar import get_all_date_counts, calculate_months_from, get_earliest_date, render_activity
+from srl.commands.config import Config
+from srl.commands.inprogress import get_in_progress
+from srl.commands.mastered import get_mastered_problems
+
+
+def add_subparser(subparsers):
+    parser = subparsers.add_parser("summary", help="Print summary of all stats")
+    parser.set_defaults(handler=handle)
+    return parser
+
+
+def handle(args, console: Console):
+    console.print("[bold]Summary[/bold]")
+    console.print("=" * 40)
+
+    total_attempts = get_total_attempts()
+    console.print(f"Total Attempts: {total_attempts}")
+
+    mastered_count = len(get_mastered_problems())
+    console.print(f"Total Mastered: {mastered_count}")
+
+    in_progress_count = len(get_in_progress())
+    console.print(f"Total In-Progress: {in_progress_count}")
+
+    console.print()
+    print_audit_stats(console)
+
+    console.print()
+    print_calendar_from_first(console)
+
+
+def get_total_attempts() -> int:
+    progress_data = load_json(PROGRESS_FILE)
+    mastered_data = load_json(MASTERED_FILE)
+    audit_data = load_json(AUDIT_FILE)
+
+    count = 0
+
+    for data in (progress_data, mastered_data):
+        for problem_data in data.values():
+            count += len(problem_data.get("history", []))
+
+    for attempt in audit_data.get("history", []):
+        if attempt.get("result") != "fail":
+            count += 1
+
+    return count
+
+
+def print_audit_stats(console: Console):
+    audit_data = load_json(AUDIT_FILE)
+    history = audit_data.get("history", [])
+
+    if not history:
+        console.print("[bold]Audit Stats:[/bold] No audits yet.")
+        return
+
+    total = len(history)
+    passed = sum(1 for entry in history if entry.get("result") == "pass")
+    failed = total - passed
+    pass_rate = (passed / total * 100) if total > 0 else 0
+
+    console.print(f"[bold]Audit Stats:[/bold]")
+    console.print(f"  Total: {total}")
+    console.print(f"  Passed: {passed} ({pass_rate:.1f}%)")
+    console.print(f"  Failed: {failed} ({100 - pass_rate:.1f}%)")
+
+
+def print_calendar_from_first(console: Console):
+    counts = get_all_date_counts()
+
+    if not counts:
+        console.print("[bold]Calendar:[/bold] No activity data.")
+        return
+
+    earliest = get_earliest_date(list(counts.keys()))
+    months = calculate_months_from(earliest)
+
+    colors = Config.load().calendar_colors
+
+    render_activity(console, counts, colors, months)
+    console.print("-" * 5)
+    from srl.commands.calendar import render_legend
+    render_legend(console, colors)

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -24,7 +24,7 @@ def add_subparser(subparsers):
 
 def handle(args, console: Console):
     console.print("[bold]Summary[/bold]")
-    console.print("=" * 40)
+    console.print(f"[dim]{'─' * 50}[/dim]")
 
     total_attempts = get_total_attempts()
     console.print(f"Total Attempts: {total_attempts}")
@@ -92,8 +92,7 @@ def print_calendar_from_first(console: Console):
     colors = Config.load().calendar_colors
 
     render_activity(console, counts, colors, months)
-    console.print("-" * 5)
+    console.print(f"[dim]{'─' * 5}[/dim]")
     from srl.commands.calendar import render_legend
 
     render_legend(console, colors)
-

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -73,7 +73,7 @@ def print_audit_stats(console: Console):
     failed = total - passed
     pass_rate = (passed / total * 100) if total > 0 else 0
 
-    console.print(f"[bold]Audit Stats:[/bold]")
+    console.print("[bold]Audit Stats:[/bold]")
     console.print(f"  Total: {total}")
     console.print(f"  Passed: {passed} ({pass_rate:.1f}%)")
     console.print(f"  Failed: {failed} ({100 - pass_rate:.1f}%)")

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -5,7 +5,12 @@ from srl.storage import (
     MASTERED_FILE,
     AUDIT_FILE,
 )
-from srl.commands.calendar import get_all_date_counts, calculate_months_from, get_earliest_date, render_activity
+from srl.commands.calendar import (
+    get_all_date_counts,
+    calculate_months_from,
+    get_earliest_date,
+    render_activity,
+)
 from srl.commands.config import Config
 from srl.commands.inprogress import get_in_progress
 from srl.commands.mastered import get_mastered_problems
@@ -89,4 +94,6 @@ def print_calendar_from_first(console: Console):
     render_activity(console, counts, colors, months)
     console.print("-" * 5)
     from srl.commands.calendar import render_legend
+
     render_legend(console, colors)
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,3 +260,9 @@ def test_ledger_count_long_flag(parser):
     assert args.command == "ledger"
     assert hasattr(args, "handler")
     assert args.count is True
+
+
+def test_summary_command(parser):
+    args = parser.parse_args(["summary"])
+    assert args.command == "summary"
+    assert hasattr(args, "handler")

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -4,17 +4,34 @@ from datetime import date, timedelta
 
 
 def test_summary_handler(parser, console, mock_data, dump_json):
-    from srl.commands.summary import handle, get_total_attempts, print_audit_stats, print_calendar_from_first
+    from srl.commands.summary import (
+        handle,
+        get_total_attempts,
+        print_audit_stats,
+        print_calendar_from_first,
+    )
 
     today_str = date.today().isoformat()
     yesterday_str = (date.today() - timedelta(days=1)).isoformat()
 
     progress_data = {
-        "Problem 1": {"url": "http://example.com/1", "history": [{"date": today_str, "rating": 3}]},
-        "Problem 2": {"url": "http://example.com/2", "history": [{"date": today_str, "rating": 4}, {"date": yesterday_str, "rating": 5}]},
+        "Problem 1": {
+            "url": "http://example.com/1",
+            "history": [{"date": today_str, "rating": 3}],
+        },
+        "Problem 2": {
+            "url": "http://example.com/2",
+            "history": [
+                {"date": today_str, "rating": 4},
+                {"date": yesterday_str, "rating": 5},
+            ],
+        },
     }
     mastered_data = {
-        "Problem 3": {"url": "http://example.com/3", "history": [{"date": today_str, "rating": 5}]},
+        "Problem 3": {
+            "url": "http://example.com/3",
+            "history": [{"date": today_str, "rating": 5}],
+        },
     }
     audit_data = {
         "history": [
@@ -43,11 +60,23 @@ def test_get_total_attempts_with_data(dump_json, mock_data):
     today_str = date.today().isoformat()
 
     progress_data = {
-        "Problem 1": {"url": "http://example.com/1", "history": [{"date": today_str, "rating": 3}]},
-        "Problem 2": {"url": "http://example.com/2", "history": [{"date": today_str, "rating": 4}, {"date": today_str, "rating": 5}]},
+        "Problem 1": {
+            "url": "http://example.com/1",
+            "history": [{"date": today_str, "rating": 3}],
+        },
+        "Problem 2": {
+            "url": "http://example.com/2",
+            "history": [
+                {"date": today_str, "rating": 4},
+                {"date": today_str, "rating": 5},
+            ],
+        },
     }
     mastered_data = {
-        "Problem 3": {"url": "http://example.com/3", "history": [{"date": today_str, "rating": 5}]},
+        "Problem 3": {
+            "url": "http://example.com/3",
+            "history": [{"date": today_str, "rating": 5}],
+        },
     }
     audit_data = {
         "history": [
@@ -77,3 +106,4 @@ def test_summary_empty_data(parser, console, mock_data, dump_json):
     assert "Total Attempts: 0" in output
     assert "Total Mastered: 0" in output
     assert "Total In-Progress: 0" in output
+

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,79 @@
+import pytest
+from rich.console import Console
+from datetime import date, timedelta
+
+
+def test_summary_handler(parser, console, mock_data, dump_json):
+    from srl.commands.summary import handle, get_total_attempts, print_audit_stats, print_calendar_from_first
+
+    today_str = date.today().isoformat()
+    yesterday_str = (date.today() - timedelta(days=1)).isoformat()
+
+    progress_data = {
+        "Problem 1": {"url": "http://example.com/1", "history": [{"date": today_str, "rating": 3}]},
+        "Problem 2": {"url": "http://example.com/2", "history": [{"date": today_str, "rating": 4}, {"date": yesterday_str, "rating": 5}]},
+    }
+    mastered_data = {
+        "Problem 3": {"url": "http://example.com/3", "history": [{"date": today_str, "rating": 5}]},
+    }
+    audit_data = {
+        "history": [
+            {"date": today_str, "problem": "Problem 3", "result": "pass"},
+            {"date": yesterday_str, "problem": "Problem 3", "result": "fail"},
+        ]
+    }
+
+    dump_json(mock_data.PROGRESS_FILE, progress_data)
+    dump_json(mock_data.MASTERED_FILE, mastered_data)
+    dump_json(mock_data.AUDIT_FILE, audit_data)
+
+    args = parser.parse_args(["summary"])
+    handle(args, console)
+
+    output = console.export_text()
+    assert "Total Attempts:" in output
+    assert "Total Mastered:" in output
+    assert "Total In-Progress:" in output
+    assert "Audit Stats:" in output
+
+
+def test_get_total_attempts_with_data(dump_json, mock_data):
+    from srl.commands.summary import get_total_attempts
+
+    today_str = date.today().isoformat()
+
+    progress_data = {
+        "Problem 1": {"url": "http://example.com/1", "history": [{"date": today_str, "rating": 3}]},
+        "Problem 2": {"url": "http://example.com/2", "history": [{"date": today_str, "rating": 4}, {"date": today_str, "rating": 5}]},
+    }
+    mastered_data = {
+        "Problem 3": {"url": "http://example.com/3", "history": [{"date": today_str, "rating": 5}]},
+    }
+    audit_data = {
+        "history": [
+            {"date": today_str, "problem": "Problem 3", "result": "pass"},
+            {"date": today_str, "problem": "Problem 3", "result": "fail"},
+        ]
+    }
+
+    dump_json(mock_data.PROGRESS_FILE, progress_data)
+    dump_json(mock_data.MASTERED_FILE, mastered_data)
+    dump_json(mock_data.AUDIT_FILE, audit_data)
+
+    assert get_total_attempts() == 5
+
+
+def test_summary_empty_data(parser, console, mock_data, dump_json):
+    from srl.commands.summary import handle
+
+    dump_json(mock_data.PROGRESS_FILE, {})
+    dump_json(mock_data.MASTERED_FILE, {})
+    dump_json(mock_data.AUDIT_FILE, {})
+
+    args = parser.parse_args(["summary"])
+    handle(args, console)
+
+    output = console.export_text()
+    assert "Total Attempts: 0" in output
+    assert "Total Mastered: 0" in output
+    assert "Total In-Progress: 0" in output

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,14 +1,9 @@
-import pytest
-from rich.console import Console
 from datetime import date, timedelta
 
 
 def test_summary_handler(parser, console, mock_data, dump_json):
     from srl.commands.summary import (
         handle,
-        get_total_attempts,
-        print_audit_stats,
-        print_calendar_from_first,
     )
 
     today_str = date.today().isoformat()


### PR DESCRIPTION
## Summary

Adds a new `summary` command that prints consolidated stats:

- Total attempts
- Total mastered problems
- Total in-progress problems  
- Audit statistics (total, passed, failed, pass rate)
- Calendar heatmap from first recorded entry

This is a convenience command replacing the common workflow:
```bash
srl ledger -c && srl mastered -c && srl inprogress -c && srl audit history && srl calendar --from-first
```

## Changes

- Added `srl/commands/summary.py` with the new command
- Updated `srl/cli.py` to register the subcommand
- Added tests in `tests/test_summary.py`
- Updated `tests/test_cli.py` with parser test
- Updated `README.md` with documentation

## Testing

All 206 tests pass.