### PR TITLE
Add --from-date flag to summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,21 @@ This prints:
 - Audit statistics (total, passed, failed, pass rate)
 - Calendar heatmap from your first recorded entry
 
+You can filter all statistics to show only activity since a specific date:
+
+```bash
+srl summary --from-date 2026-01-01
+```
+
+This filters:
+- Total attempts to only those since the date
+- Total mastered to problems mastered since the date
+- Total in-progress to problems with activity since the date
+- Audit stats to only audits since the date
+- Calendar shows from that date instead of from first entry
+
+Date format: `YYYY-MM-DD` (ISO format)
+
 ---
 
 ### Server Command

--- a/README.md
+++ b/README.md
@@ -469,15 +469,6 @@ You can filter all statistics to show only activity since a specific date:
 srl summary --from-date 2026-01-01
 ```
 
-This filters:
-- Total attempts to only those since the date
-- Total mastered to problems mastered since the date
-- Total in-progress to problems with activity since the date
-- Audit stats to only audits since the date
-- Calendar shows from that date instead of from first entry
-
-Date format: `YYYY-MM-DD` (ISO format)
-
 ---
 
 ### Server Command

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -37,7 +37,8 @@ def handle(args, console: Console):
     title = "Summary"
     if from_date:
         title = f"Summary (since {from_date_str})"
-    console.print(f"[dim]── {title} {'─' * 50}[/dim]")
+    console.print(f"[bold]{title}[/bold]")
+    console.print(f"[dim]{'─' * 50}[/dim]")
 
     total_attempts = get_total_attempts(from_date)
     console.print(f"Total Attempts: {total_attempts}")
@@ -67,8 +68,7 @@ def get_total_attempts(from_date: date | None = None) -> int:
             history = problem_data.get("history", [])
             if from_date:
                 history = [
-                    h for h in history
-                    if date.fromisoformat(h["date"]) >= from_date
+                    h for h in history if date.fromisoformat(h["date"]) >= from_date
                 ]
             count += len(history)
 
@@ -110,8 +110,7 @@ def get_in_progress_filtered(from_date: date | None = None) -> list:
             result.append({"name": name, "url": info.get("url", "")})
         else:
             has_activity = any(
-                date.fromisoformat(h["date"]) >= from_date
-                for h in history
+                date.fromisoformat(h["date"]) >= from_date for h in history
             )
             if has_activity:
                 result.append({"name": name, "url": info.get("url", "")})
@@ -123,10 +122,7 @@ def print_audit_stats(console: Console, from_date: date | None = None):
     history = audit_data.get("history", [])
 
     if from_date:
-        history = [
-            h for h in history
-            if date.fromisoformat(h["date"]) >= from_date
-        ]
+        history = [h for h in history if date.fromisoformat(h["date"]) >= from_date]
 
     if not history:
         console.print("[bold]Audit Stats:[/bold] No audits yet.")
@@ -163,3 +159,4 @@ def print_calendar(console: Console, from_date: date | None = None):
     from srl.commands.calendar import render_legend
 
     render_legend(console, colors)
+

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -13,7 +13,6 @@ from srl.commands.calendar import (
     render_activity,
 )
 from srl.commands.config import Config
-from srl.commands.inprogress import get_in_progress
 from srl.commands.mastered import get_mastered_problems as get_all_mastered_problems
 
 

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -89,9 +89,8 @@ def get_total_attempts(from_date: date | None = None) -> int:
 
 
 def get_mastered_problems(from_date: date | None = None) -> list:
-    all_mastered = get_all_mastered_problems()
     if from_date is None:
-        return all_mastered
+        return get_all_mastered_problems()
 
     mastered = []
     data = load_json(MASTERED_FILE)

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -32,7 +32,12 @@ def handle(args, console: Console):
     from_date_str = getattr(args, "from_date", None)
     from_date = None
     if from_date_str:
-        from_date = date.fromisoformat(from_date_str)
+        try:
+            from_date = date.fromisoformat(from_date_str)
+        except ValueError:
+            console.print(f"[red]Invalid date format: {from_date_str}[/red]")
+            console.print("[yellow]Use ISO format: YYYY-MM-DD (e.g., 2024-01-15)[/yellow]")
+            return
 
     title = "Summary"
     if from_date:

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -36,7 +36,9 @@ def handle(args, console: Console):
             from_date = date.fromisoformat(from_date_str)
         except ValueError:
             console.print(f"[red]Invalid date format: {from_date_str}[/red]")
-            console.print("[yellow]Use ISO format: YYYY-MM-DD (e.g., 2024-01-15)[/yellow]")
+            console.print(
+                "[yellow]Use ISO format: YYYY-MM-DD (e.g., 2024-01-15)[/yellow]"
+            )
             return
 
     title = "Summary"
@@ -164,4 +166,3 @@ def print_calendar(console: Console, from_date: date | None = None):
     from srl.commands.calendar import render_legend
 
     render_legend(console, colors)
-

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -1,4 +1,5 @@
 from rich.console import Console
+from datetime import date
 from srl.storage import (
     load_json,
     PROGRESS_FILE,
@@ -13,36 +14,48 @@ from srl.commands.calendar import (
 )
 from srl.commands.config import Config
 from srl.commands.inprogress import get_in_progress
-from srl.commands.mastered import get_mastered_problems
+from srl.commands.mastered import get_mastered_problems as get_all_mastered_problems
 
 
 def add_subparser(subparsers):
     parser = subparsers.add_parser("summary", help="Print summary of all stats")
+    parser.add_argument(
+        "--from-date",
+        type=str,
+        help="Show stats since this date (ISO format: YYYY-MM-DD)",
+    )
     parser.set_defaults(handler=handle)
     return parser
 
 
 def handle(args, console: Console):
-    console.print("[bold]Summary[/bold]")
-    console.print(f"[dim]{'─' * 50}[/dim]")
+    from_date_str = getattr(args, "from_date", None)
+    from_date = None
+    if from_date_str:
+        from_date = date.fromisoformat(from_date_str)
 
-    total_attempts = get_total_attempts()
+    title = "Summary"
+    if from_date:
+        title = f"Summary (since {from_date_str})"
+    console.print(f"[dim]── {title} {'─' * 50}[/dim]")
+
+    total_attempts = get_total_attempts(from_date)
     console.print(f"Total Attempts: {total_attempts}")
 
-    mastered_count = len(get_mastered_problems())
+    mastered_count = len(get_mastered_problems(from_date))
     console.print(f"Total Mastered: {mastered_count}")
 
-    in_progress_count = len(get_in_progress())
+    in_progress_count = len(get_in_progress_filtered(from_date))
     console.print(f"Total In-Progress: {in_progress_count}")
 
     console.print()
-    print_audit_stats(console)
+    print_audit_stats(console, from_date)
 
     console.print()
-    print_calendar_from_first(console)
+    print_calendar(console, from_date)
 
 
-def get_total_attempts() -> int:
+def get_total_attempts(from_date: date | None = None) -> int:
     progress_data = load_json(PROGRESS_FILE)
     mastered_data = load_json(MASTERED_FILE)
     audit_data = load_json(AUDIT_FILE)
@@ -51,18 +64,69 @@ def get_total_attempts() -> int:
 
     for data in (progress_data, mastered_data):
         for problem_data in data.values():
-            count += len(problem_data.get("history", []))
+            history = problem_data.get("history", [])
+            if from_date:
+                history = [
+                    h for h in history
+                    if date.fromisoformat(h["date"]) >= from_date
+                ]
+            count += len(history)
 
     for attempt in audit_data.get("history", []):
         if attempt.get("result") != "fail":
-            count += 1
+            attempt_date = date.fromisoformat(attempt["date"])
+            if from_date is None or attempt_date >= from_date:
+                count += 1
 
     return count
 
 
-def print_audit_stats(console: Console):
+def get_mastered_problems(from_date: date | None = None) -> list:
+    all_mastered = get_all_mastered_problems()
+    if from_date is None:
+        return all_mastered
+
+    mastered = []
+    data = load_json(MASTERED_FILE)
+    for name, info in data.items():
+        history = info.get("history", [])
+        if not history:
+            continue
+        last_attempt = history[-1]
+        last_date = date.fromisoformat(last_attempt["date"])
+        if last_date >= from_date:
+            mastered.append((name, len(history), last_attempt["date"]))
+    return mastered
+
+
+def get_in_progress_filtered(from_date: date | None = None) -> list:
+    data = load_json(PROGRESS_FILE)
+    result = []
+    for name, info in data.items():
+        history = info.get("history", [])
+        if not history:
+            continue
+        if from_date is None:
+            result.append({"name": name, "url": info.get("url", "")})
+        else:
+            has_activity = any(
+                date.fromisoformat(h["date"]) >= from_date
+                for h in history
+            )
+            if has_activity:
+                result.append({"name": name, "url": info.get("url", "")})
+    return result
+
+
+def print_audit_stats(console: Console, from_date: date | None = None):
     audit_data = load_json(AUDIT_FILE)
     history = audit_data.get("history", [])
+
+    if from_date:
+        history = [
+            h for h in history
+            if date.fromisoformat(h["date"]) >= from_date
+        ]
 
     if not history:
         console.print("[bold]Audit Stats:[/bold] No audits yet.")
@@ -79,15 +143,18 @@ def print_audit_stats(console: Console):
     console.print(f"  Failed: {failed} ({100 - pass_rate:.1f}%)")
 
 
-def print_calendar_from_first(console: Console):
+def print_calendar(console: Console, from_date: date | None = None):
     counts = get_all_date_counts()
 
     if not counts:
         console.print("[bold]Calendar:[/bold] No activity data.")
         return
 
-    earliest = get_earliest_date(list(counts.keys()))
-    months = calculate_months_from(earliest)
+    if from_date:
+        months = calculate_months_from(from_date)
+    else:
+        earliest = get_earliest_date(list(counts.keys()))
+        months = calculate_months_from(earliest)
 
     colors = Config.load().calendar_colors
 

--- a/srl/commands/summary.py
+++ b/srl/commands/summary.py
@@ -130,7 +130,7 @@ def print_audit_stats(console: Console, from_date: date | None = None):
         history = [h for h in history if date.fromisoformat(h["date"]) >= from_date]
 
     if not history:
-        console.print("[bold]Audit Stats:[/bold] No audits yet.")
+        console.print("[bold]Audit Stats:[/bold] No audits yet")
         return
 
     total = len(history)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -266,3 +266,10 @@ def test_summary_command(parser):
     args = parser.parse_args(["summary"])
     assert args.command == "summary"
     assert hasattr(args, "handler")
+
+
+def test_summary_from_date(parser):
+    args = parser.parse_args(["summary", "--from-date", "2024-01-15"])
+    assert args.command == "summary"
+    assert hasattr(args, "handler")
+    assert args.from_date == "2024-01-15"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -43,7 +43,6 @@ def test_summary_handler(parser, console, mock_data, dump_json):
     handle(args, console)
 
     output = console.export_text()
-    assert "── Summary ─" in output
     assert "Total Attempts:" in output
     assert "Total Mastered:" in output
     assert "Total In-Progress:" in output
@@ -158,4 +157,3 @@ def test_summary_empty_data(parser, console, mock_data, dump_json):
     assert "Total Attempts: 0" in output
     assert "Total Mastered: 0" in output
     assert "Total In-Progress: 0" in output
-

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -43,10 +43,67 @@ def test_summary_handler(parser, console, mock_data, dump_json):
     handle(args, console)
 
     output = console.export_text()
+    assert "── Summary ─" in output
     assert "Total Attempts:" in output
     assert "Total Mastered:" in output
     assert "Total In-Progress:" in output
     assert "Audit Stats:" in output
+
+
+def test_summary_with_from_date(parser, console, mock_data, dump_json):
+    from srl.commands.summary import handle
+
+    today_str = date.today().isoformat()
+    yesterday_str = (date.today() - timedelta(days=1)).isoformat()
+    last_week_str = (date.today() - timedelta(days=7)).isoformat()
+
+    progress_data = {
+        "Problem 1": {
+            "url": "http://example.com/1",
+            "history": [
+                {"date": today_str, "rating": 3},
+                {"date": last_week_str, "rating": 5},
+            ],
+        },
+        "Problem 2": {
+            "url": "http://example.com/2",
+            "history": [{"date": last_week_str, "rating": 4}],
+        },
+    }
+    mastered_data = {
+        "Problem 3": {
+            "url": "http://example.com/3",
+            "history": [{"date": today_str, "rating": 5}],
+        },
+        "Problem 4": {
+            "url": "http://example.com/4",
+            "history": [
+                {"date": last_week_str, "rating": 5},
+            ],
+        },
+    }
+    audit_data = {
+        "history": [
+            {"date": today_str, "problem": "Problem 3", "result": "pass"},
+            {"date": last_week_str, "problem": "Problem 3", "result": "pass"},
+        ]
+    }
+
+    dump_json(mock_data.PROGRESS_FILE, progress_data)
+    dump_json(mock_data.MASTERED_FILE, mastered_data)
+    dump_json(mock_data.AUDIT_FILE, audit_data)
+
+    from_date = (date.today() - timedelta(days=2)).isoformat()
+    args = parser.parse_args(["summary", "--from-date", from_date])
+    handle(args, console)
+
+    output = console.export_text()
+    assert f"Summary (since {from_date})" in output
+    assert "Total Attempts: 3" in output
+    assert "Total Mastered: 1" in output
+    assert "Total In-Progress: 1" in output
+    assert "Audit Stats:" in output
+    assert "Total: 1" in output
 
 
 def test_get_total_attempts_with_data(dump_json, mock_data):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -53,7 +53,6 @@ def test_summary_with_from_date(parser, console, mock_data, dump_json):
     from srl.commands.summary import handle
 
     today_str = date.today().isoformat()
-    yesterday_str = (date.today() - timedelta(days=1)).isoformat()
     last_week_str = (date.today() - timedelta(days=7)).isoformat()
 
     progress_data = {


### PR DESCRIPTION
## Summary

Adds a `--from-date` flag to the `summary` command that filters all stats to show only activity since a given date.

## Changes

- Added `--from-date` argument to parse ISO format date (YYYY-MM-DD)
- Updated all filtering functions to accept optional `from_date` parameter:
  - `get_total_attempts()` - filters history entries >= from_date
  - `get_mastered_problems()` - filters to problems mastered since date
  - `get_in_progress_filtered()` - filters to problems with activity since date
  - `print_audit_stats()` - filters audit history >= from_date
  - `print_calendar()` - uses from_date as earliest if provided
- Title includes "(since YYYY-MM-DD)" when flag is provided
- Updated README documentation

## Example

```bash
# All time
srl summary

# Since 2026-01-01
srl summary --from-date 2026-01-01
```

## Testing

All 208 tests pass.