### PR TITLE
Fix/keyboard interrupt restore

### DIFF
--- a/srl/commands/backup.py
+++ b/srl/commands/backup.py
@@ -160,14 +160,18 @@ def restore_handle(args, console: Console):
     if auto_yes:
         handle(args, console)
     else:
-        console.print("This will overwrite current SRL state. Continue? [y/N]: ", end="")
-        if input().strip().lower() not in ("y", "yes"):
-            console.print("[yellow]Restore cancelled.[/yellow]")
-            return
+        try:
+            console.print("This will overwrite current SRL state. Continue? [y/N]: ", end="")
+            if input().strip().lower() not in ("y", "yes"):
+                console.print("[yellow]Restore cancelled.[/yellow]")
+                return
 
-        console.print("Create a backup of current state before restoring? [y/N]: ", end="")
-        if input().strip().lower() in ("y", "yes"):
-            handle(args, console)
+            console.print("Create a backup of current state before restoring? [y/N]: ", end="")
+            if input().strip().lower() in ("y", "yes"):
+                handle(args, console)
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Restore cancelled.[/yellow]")
+            return
 
     try:
         with tarfile.open(backup_path, "r:gz") as tar:

--- a/tests/test_commands/test_backup_list_verify.py
+++ b/tests/test_commands/test_backup_list_verify.py
@@ -375,3 +375,41 @@ class TestRestore:
 
         output = _get_output(console)
         assert "not found" in output
+
+    def test_keyboard_interrupt_at_first_prompt(self, test_dirs, console, monkeypatch, tmp_path):
+        tmp_path, data_dir, backup_dir = test_dirs
+        _patch(monkeypatch, data_dir, backup_dir)
+
+        archive = _create_archive(backup_dir, "backup-2026-01-01T000000.tar.gz")
+
+        def raise_interrupt():
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr("builtins.input", raise_interrupt)
+
+        args = SimpleNamespace(file=str(archive))
+        backup.restore_handle(args, console)
+
+        assert "Restore cancelled" in _get_output(console)
+
+    def test_keyboard_interrupt_at_second_prompt(self, test_dirs, console, monkeypatch, tmp_path):
+        tmp_path, data_dir, backup_dir = test_dirs
+        _patch(monkeypatch, data_dir, backup_dir)
+
+        archive = _create_archive(backup_dir, "backup-2026-01-01T000000.tar.gz")
+
+        responses = iter(["y", KeyboardInterrupt()])
+
+        def input_side_effect():
+            val = next(responses)
+            if isinstance(val, BaseException):
+                raise val
+            return val
+
+        monkeypatch.setattr("builtins.input", input_side_effect)
+
+        args = SimpleNamespace(file=str(archive))
+        backup.restore_handle(args, console)
+
+        output = _get_output(console)
+        assert "Restore cancelled" in output


### PR DESCRIPTION
Fixes #98      

## Summary                                                                                                                                                                                                                                                                                                                                                                                                                   
Wrapped both `input()` calls in `restore_handle` in a `try/except KeyboardInterrupt` so that pressing Ctrl+C at either interactive prompt exits gracefully with a cancellation message, as opposed to raising an unhandled exception.
## Changes                                                            
  - `srl/commands/backup.py`:  added `try/except KeyboardInterrupt` around the two confirmation prompts in `restore_handle`                                                                                          
  - `tests/test_commands/test_backup_list_verify.py`: added two tests covering a keyboard interrupt at the first prompt and at the second prompt