### PR TITLE
Improve speed of `srl server` testing suite

### DIFF
--- a/srl/commands/server.py
+++ b/srl/commands/server.py
@@ -62,6 +62,29 @@ def execute_command(argv, console: Console) -> dict:
     }
 
 
+def root_handler(body: str, console: Console) -> tuple[int, str]:
+    if not body:
+        return 400, "Missing Body"
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return 400, "Invalid JSON"
+
+    if "argv" not in data:
+        return 400, "Missing argv"
+
+    argv = data["argv"]
+    if not isinstance(argv, list):
+        return 400, "argv must be a list"
+
+    result = execute_command(argv, console)
+    if result["status"] == "error":
+        return 400, result["error"]
+
+    return 200, json.dumps(result).encode("utf-8")
+
+
 class SRLRequestHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         path = urlparse(self.path).path
@@ -83,29 +106,15 @@ class SRLRequestHandler(BaseHTTPRequestHandler):
             else ""
         )
 
-        if not body:
-            self._send_error("Missing body")
-            return
+        code, response = root_handler(body, console)
 
-        try:
-            data = json.loads(body)
-        except json.JSONDecodeError:
-            self._send_error("Invalid JSON")
-            return
-
-        if "argv" not in data:
-            self._send_error("Missing argv")
-            return
-        argv = data["argv"]
-        if not isinstance(argv, list):
-            self._send_error("argv must be a list")
-            return
-
-        result = execute_command(argv, console)
-        if result["status"] == "error":
-            self._send_error(result["error"])
+        if code != 200:
+            self._send_error(response, code)
         else:
-            self._send_success(result)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(response)
 
     def handle_backup(self):
         content_type = self.headers.get("Content-Type")

--- a/srl/commands/server.py
+++ b/srl/commands/server.py
@@ -85,6 +85,31 @@ def root_handler(body: str, console: Console) -> tuple[int, str]:
     return 200, json.dumps(result).encode("utf-8")
 
 
+def verify_backup_request(content_type: str, content_length: int) -> tuple[int, str]:
+    if content_type != "application/gzip":
+        return 415, "Expected application/gzip"
+    if content_length <= 0:
+        return 400, "Missing body"
+
+    return 200, ""
+
+
+def backup_handler(data, console: Console) -> tuple[int, str]:
+    filename, archive_path = resolve_backup_path()
+    with open(archive_path, "wb") as f:
+        f.write(data)
+
+    verify_args = SimpleNamespace(file=str(archive_path))
+    if verify_handle(verify_args, console):
+        if archive_path.exists():
+            archive_path.unlink()
+        return 400, "Bad data"
+
+    prune_old_backups()
+
+    return 200, ""
+
+
 class SRLRequestHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         path = urlparse(self.path).path
@@ -118,30 +143,21 @@ class SRLRequestHandler(BaseHTTPRequestHandler):
 
     def handle_backup(self):
         content_type = self.headers.get("Content-Type")
-        if content_type != "application/gzip":
-            self._send_error("Expected application/gzip", code=415)
-            return
-
         length = int(self.headers.get("Content-Length", 0))
-        if length <= 0:
-            self._send_error("Missing body")
+        code, response = verify_backup_request(content_type, length)
+        if code != 200:
+            self._send_error(response, code)
             return
 
         data = self.rfile.read(length)
-        filename, archive_path = resolve_backup_path()
-        with open(archive_path, "wb") as f:
-            f.write(data)
+        console = self.server.console
+        code, response = backup_handler(data, console)
 
-        verify_args = SimpleNamespace(file=str(archive_path))
-        if verify_handle(verify_args, self.server.console):
-            self._send_error("Bad data")
-            if archive_path.exists():
-                archive_path.unlink()
-            return
-
-        prune_old_backups()
-
-        self._send_success()
+        if code != 200:
+            self._send_error(response, code)
+        else:
+            self.send_response(200)
+            self.end_headers()
 
     def _send_error(self, error_msg: str, code: int = 400):
         self.send_response(code)
@@ -152,16 +168,6 @@ class SRLRequestHandler(BaseHTTPRequestHandler):
                 "utf-8"
             )
         )
-
-    def _send_success(self, result: dict | None = None):
-        if result is not None:
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps(result).encode("utf-8"))
-        else:
-            self.send_response(200)
-            self.end_headers()
 
     def log_message(self, format, *args):
         message = format % args

--- a/srl/commands/server.py
+++ b/srl/commands/server.py
@@ -134,30 +134,29 @@ class SRLRequestHandler(BaseHTTPRequestHandler):
         code, response = root_handler(body, console)
 
         if code != 200:
-            self._send_error(response, code)
-        else:
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(response)
+            return self._send_error(response, code)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(response)
 
     def handle_backup(self):
         content_type = self.headers.get("Content-Type")
         length = int(self.headers.get("Content-Length", 0))
         code, response = verify_backup_request(content_type, length)
         if code != 200:
-            self._send_error(response, code)
-            return
+            return self._send_error(response, code)
 
         data = self.rfile.read(length)
         console = self.server.console
         code, response = backup_handler(data, console)
 
         if code != 200:
-            self._send_error(response, code)
-        else:
-            self.send_response(200)
-            self.end_headers()
+            return self._send_error(response, code)
+
+        self.send_response(200)
+        self.end_headers()
 
     def _send_error(self, error_msg: str, code: int = 400):
         self.send_response(code)

--- a/tests/test_commands/test_server.py
+++ b/tests/test_commands/test_server.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from http.server import HTTPServer
 from http.client import HTTPConnection
 
+import pytest
 from srl.commands import server
 
 
@@ -66,54 +67,93 @@ def _post_backup(port, body, content_type="application/gzip", content_length=Non
     return status, data.decode("utf-8")
 
 
-def test_server_ledger_command(console):
+@pytest.fixture(scope="module")
+def live_server():
+    """Start the server once for all integration tests in this module."""
+    from rich.console import Console
+
+    console = Console()
     port = _start_server(console)
+    yield port
 
-    conn = HTTPConnection("127.0.0.1", port)
+
+def test_root_handler_missing_body(console):
+    code, response = server.root_handler("", console)
+    assert code == 400
+    assert "Missing Body" in response
+
+
+def test_root_handler_invalid_json(console):
+    code, response = server.root_handler("not json", console)
+    assert code == 400
+    assert "Invalid JSON" in response
+
+
+def test_root_handler_missing_argv(console):
+    code, response = server.root_handler("{}", console)
+    assert code == 400
+    assert "Missing argv" in response
+
+
+def test_root_handler_argv_not_list(console):
+    code, response = server.root_handler('{"argv": "ledger"}', console)
+    assert code == 400
+    assert "argv must be a list" in response
+
+
+def test_root_handler_ledger_command(console):
     body = json.dumps({"argv": ["ledger", "-c"]})
-    conn.request("POST", "/", body=body, headers={"Content-Type": "application/json"})
-    resp = conn.getresponse()
-    data = json.loads(resp.read().decode("utf-8"))
-    conn.close()
-
+    code, response = server.root_handler(body, console)
+    assert code == 200
+    data = json.loads(response)
     assert data["status"] == "success"
     assert "Total attempts: 0" in data["output"]
 
 
-def test_server_backup_not_gzip(console):
-    port = _start_server(console)
-
-    status, data = _post_backup(port, b"some data", content_type="text/plain")
-
-    assert status == 415
-    response = json.loads(data)
-    assert response["status"] == "error"
-    assert response["error"] == "Expected application/gzip"
+def test_verify_backup_request_wrong_content_type():
+    code, msg = server.verify_backup_request("text/plain", 10)
+    assert code == 415
+    assert "Expected application/gzip" in msg
 
 
-def test_server_backup_missing_body(console):
-    port = _start_server(console)
-
-    status, data = _post_backup(port, b"", content_length=0)
-
-    assert status == 400
-    response = json.loads(data)
-    assert response["status"] == "error"
-    assert response["error"] == "Missing body"
+def test_verify_backup_request_missing_body():
+    code, msg = server.verify_backup_request("application/gzip", 0)
+    assert code == 400
+    assert "Missing body" in msg
 
 
-def test_server_backup_bad_data(console, mock_data):
-    port = _start_server(console)
+def test_verify_backup_request_valid():
+    code, msg = server.verify_backup_request("application/gzip", 10)
+    assert code == 200
+    assert msg == ""
 
-    status, data = _post_backup(port, b"not a valid gzip file")
 
-    assert status == 400
-    response = json.loads(data)
-    assert response["status"] == "error"
-    assert response["error"] == "Bad data"
+def test_backup_handler_bad_data(console, mock_data):
+    code, msg = server.backup_handler(b"not a valid gzip file", console)
+    assert code == 400
+    assert "Bad data" in msg
 
     backups = list(mock_data.BACKUP_DIR.glob("backup-*.tar.gz"))
     assert len(backups) == 0, "Backup file should be deleted after bad data"
+
+
+def test_backup_handler_success_and_prunes(console, mock_data, monkeypatch):
+    called_prune = False
+
+    def mock_prune():
+        nonlocal called_prune
+        called_prune = True
+
+    monkeypatch.setattr("srl.commands.server.prune_old_backups", mock_prune)
+
+    valid_backup = _create_valid_backup()
+    code, msg = server.backup_handler(valid_backup, console)
+
+    assert code == 200
+    assert called_prune, "prune_old_backups should be called on successful backup"
+
+    backups = list(mock_data.BACKUP_DIR.glob("backup-*.tar.gz"))
+    assert len(backups) == 1, "Valid backup file should be saved"
 
 
 def _create_valid_backup():
@@ -132,22 +172,21 @@ def _create_valid_backup():
     return buffer.getvalue()
 
 
-def test_server_backup_success_and_prunes(console, mock_data, monkeypatch):
-    port = _start_server(console)
+def test_integration_ledger_command(live_server, console):
+    conn = HTTPConnection("127.0.0.1", live_server)
+    body = json.dumps({"argv": ["ledger", "-c"]})
+    conn.request("POST", "/", body=body, headers={"Content-Type": "application/json"})
+    resp = conn.getresponse()
+    data = json.loads(resp.read().decode("utf-8"))
+    conn.close()
 
-    called_prune = False
+    assert data["status"] == "success"
+    assert "Total attempts: 0" in data["output"]
 
-    def mock_prune():
-        nonlocal called_prune
-        called_prune = True
 
-    monkeypatch.setattr("srl.commands.server.prune_old_backups", mock_prune)
-
-    valid_backup = _create_valid_backup()
-    status, data = _post_backup(port, valid_backup)
-
-    assert status == 200
-    assert called_prune, "prune_old_backups should be called on successful backup"
-
-    backups = list(mock_data.BACKUP_DIR.glob("backup-*.tar.gz"))
-    assert len(backups) == 1, "Valid backup file should be saved"
+def test_integration_backup_not_gzip(live_server):
+    status, data = _post_backup(live_server, b"some data", content_type="text/plain")
+    assert status == 415
+    response = json.loads(data)
+    assert response["status"] == "error"
+    assert response["error"] == "Expected application/gzip"

--- a/tests/test_commands/test_server.py
+++ b/tests/test_commands/test_server.py
@@ -172,7 +172,7 @@ def _create_valid_backup():
     return buffer.getvalue()
 
 
-def test_integration_ledger_command(live_server, console):
+def test_integration_ledger_command(live_server):
     conn = HTTPConnection("127.0.0.1", live_server)
     body = json.dumps({"argv": ["ledger", "-c"]})
     conn.request("POST", "/", body=body, headers={"Content-Type": "application/json"})


### PR DESCRIPTION
- Refactors `server.py` to split out handler logic, so that it can be tested with pure unit tests
- Refactors `test_server.py` to only start the server once for integration tests