### PR TITLE
Improve take command error feedback

### DIFF
--- a/srl/commands/take.py
+++ b/srl/commands/take.py
@@ -1,5 +1,5 @@
 from rich.console import Console
-from srl.commands import list_
+from srl.commands.list_ import get_due_problems
 import argparse
 
 
@@ -35,17 +35,16 @@ def handle(args, console: Console):
     index: int = args.number
     if index <= 0:
         return
-    problem = None
-    url = None
-    due_problems = list_.get_due_problems()
+    due_problems = get_due_problems()
 
-    if due_problems and 0 < index <= len(due_problems):
-        problem, url = due_problems[index - 1]
-
-    if not problem:
+    if index > len(due_problems):
+        console.print(f"[red]Invalid problem number:[/red] {index}")
         return
 
+    problem, url = due_problems[index - 1]
+
     if url_requested and not url:
+        console.print(f"[red]No URL found for '{problem}'.[/red]")
         return
 
     if url_requested:

--- a/tests/test_commands/test_take.py
+++ b/tests/test_commands/test_take.py
@@ -24,7 +24,7 @@ def test_take_index_out_of_bounds_high(console):
     args = SimpleNamespace(number=2)  # Index 2 for 1 problem is out of bounds
     take.handle(args=args, console=console)
     output = console.export_text()
-    assert output == ""
+    assert output == "Invalid problem number: 2\n"
 
 
 def test_take_index_zero_is_invalid(console):
@@ -75,7 +75,7 @@ def test_take_print_problem_from_due_problem_without_url(console, backdate_probl
     assert "Open in Browser" not in output
 
 
-def test_take_prints_none_with_url_flag_but_no_url(console, backdate_problem):
+def test_take_reports_missing_url(console, backdate_problem):
     problem = "Problem Without URL"
     add_args = SimpleNamespace(name=problem, rating=4)
     add.handle(add_args, console)
@@ -87,7 +87,7 @@ def test_take_prints_none_with_url_flag_but_no_url(console, backdate_problem):
     take_args = SimpleNamespace(number=1, action=None, rating=None, url=True)
     take.handle(args=take_args, console=console)
     output = console.export_text()
-    assert not output
+    assert output == "No URL found for 'Problem Without URL'.\n"
 
 
 def test_take_print_url_from_nextup_problem(console):


### PR DESCRIPTION
Closes #122 

Adds clear feedback when `srl take` receives an out-of-range number or `--url` is used for a problem without a saved URL.